### PR TITLE
Setup/setting target coverage on 80 codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ coverage:
     project:
       default:
         target: 80%
-        threshold: 2
+        threshold: 2%


### PR DESCRIPTION
Adding a new codecov.yml file in the root of our repo project, in order to set a target coverage to 80% when merging to the main.