### PR TITLE
userstory/US-3-Create-shapes-for-the-campus-buildings-SGW-version+color+labels

### DIFF
--- a/main/components/Buildings/data/SGW_data.json
+++ b/main/components/Buildings/data/SGW_data.json
@@ -5,9 +5,17 @@
     "code": "B",
     "name": "B Annex",
     "address": "2160 Bishop St.",
-    "latitude": 45.497856,
-    "longitude": -73.579588,
-    "aliases": ["B", "B Annex", "B Building"]
+    "latitude": 45.497826,
+    "longitude": -73.5795,
+    "aliases": ["B", "B Annex", "B Building"],
+    "polygon": [
+      { "latitude": 45.497887, "longitude": -73.5793896 },
+      { "latitude": 45.4979102, "longitude": -73.5794406 },
+      { "latitude": 45.4979241, "longitude": -73.5794655 },
+      { "latitude": 45.4977507, "longitude": -73.5796322 },
+      { "latitude": 45.4977144, "longitude": -73.5795607 },
+      { "latitude": 45.497887, "longitude": -73.5793896 }
+    ]
   },
   {
     "id": "SGW-CI",
@@ -16,8 +24,20 @@
     "name": "CI Annex",
     "address": "2149 Mackay St.",
     "latitude": 45.497467,
-    "longitude": -73.579925,
-    "aliases": ["CI", "CI Annex", "CI Building"]
+    "longitude": -73.5799,
+    "aliases": ["CI", "CI Annex", "CI Building"],
+    "polygon": [
+      { "latitude": 45.4974061, "longitude": -73.5800149 },
+      { "latitude": 45.4973958, "longitude": -73.5799938 },
+      { "latitude": 45.4973868, "longitude": -73.5799742 },
+      { "latitude": 45.497373, "longitude": -73.5799734 },
+      { "latitude": 45.4973615, "longitude": -73.5799483 },
+      { "latitude": 45.4973632, "longitude": -73.5799218 },
+      { "latitude": 45.4974912, "longitude": -73.5798023 },
+      { "latitude": 45.4975407, "longitude": -73.5797543 },
+      { "latitude": 45.4975819, "longitude": -73.5798422 },
+      { "latitude": 45.4974061, "longitude": -73.5800149 }
+    ]
   },
   {
     "id": "SGW-CL",
@@ -25,9 +45,20 @@
     "code": "CL",
     "name": "CL Annex",
     "address": "1665 Ste-Catherine St. W.",
-    "latitude": 45.496944,
-    "longitude": -73.5781,
-    "aliases": ["CL", "CL Annex", "CL Building"]
+    "latitude": 45.494204,
+    "longitude": -73.5793,
+    "aliases": ["CL", "CL Annex", "CL Building"],
+    "polygon": [
+      { "latitude": 45.4941615, "longitude": -73.5796402 },
+      { "latitude": 45.4939635, "longitude": -73.5793327 },
+      { "latitude": 45.4939729, "longitude": -73.5792952 },
+      { "latitude": 45.4939832, "longitude": -73.5792697 },
+      { "latitude": 45.494002, "longitude": -73.5792348 },
+      { "latitude": 45.4940152, "longitude": -73.5792201 },
+      { "latitude": 45.4942577, "longitude": -73.5789277 },
+      { "latitude": 45.4944711, "longitude": -73.5792777 },
+      { "latitude": 45.4941615, "longitude": -73.5796402 }
+    ]
   },
   {
     "id": "SGW-D",
@@ -35,9 +66,20 @@
     "code": "D",
     "name": "D Annex",
     "address": "2140 Bishop St.",
-    "latitude": 45.497319,
-    "longitude": -73.579414,
-    "aliases": ["D", "D Annex", "D Building"]
+    "latitude": 45.49776,
+    "longitude": -73.57935,
+    "aliases": ["D", "D Annex", "D Building"],
+    "polygon": [
+      { "latitude": 45.497816, "longitude": -73.5792401 },
+      { "latitude": 45.4978341, "longitude": -73.5792822 },
+      { "latitude": 45.4978508, "longitude": -73.5793152 },
+      { "latitude": 45.4977565, "longitude": -73.579405 },
+      { "latitude": 45.4977075, "longitude": -73.5794536 },
+      { "latitude": 45.4976872, "longitude": -73.5794096 },
+      { "latitude": 45.4977301, "longitude": -73.5793694 },
+      { "latitude": 45.4977169, "longitude": -73.5793354 },
+      { "latitude": 45.497816, "longitude": -73.5792401 }
+    ]
   },
   {
     "id": "SGW-EN",
@@ -45,9 +87,23 @@
     "code": "EN",
     "name": "EN Annex",
     "address": "2070 Mackay St.",
-    "latitude": 45.49655,
-    "longitude": -73.57936,
-    "aliases": ["EN", "EN Annex", "EN Building"]
+    "latitude": 45.49685,
+    "longitude": -73.5796,
+    "aliases": ["EN", "EN Annex", "EN Building"],
+    "polygon": [
+      { "latitude": 45.4968834, "longitude": -73.5794977 },
+      { "latitude": 45.4968982, "longitude": -73.5794838 },
+      { "latitude": 45.4969165, "longitude": -73.5795233 },
+      { "latitude": 45.4969267, "longitude": -73.5795137 },
+      { "latitude": 45.4969507, "longitude": -73.5795655 },
+      { "latitude": 45.4969271, "longitude": -73.5795884 },
+      { "latitude": 45.4968297, "longitude": -73.5796809 },
+      { "latitude": 45.4967146, "longitude": -73.5797877 },
+      { "latitude": 45.496689, "longitude": -73.5797324 },
+      { "latitude": 45.4968073, "longitude": -73.579621 },
+      { "latitude": 45.4967907, "longitude": -73.5795851 },
+      { "latitude": 45.4968834, "longitude": -73.5794977 }
+    ]
   },
   {
     "id": "SGW-ER",
@@ -55,9 +111,20 @@
     "code": "ER",
     "name": "ER Building",
     "address": "2155 Guy St.",
-    "latitude": 45.49595,
-    "longitude": -73.5799,
-    "aliases": ["ER", "ER Building"]
+    "latitude": 45.4964,
+    "longitude": -73.58,
+    "aliases": ["ER", "ER Building"],
+    "polygon": [
+      { "latitude": 45.4965177, "longitude": -73.5796317 },
+      { "latitude": 45.4966784, "longitude": -73.5799683 },
+      { "latitude": 45.4962366, "longitude": -73.5803907 },
+      { "latitude": 45.4961873, "longitude": -73.5802304 },
+      { "latitude": 45.4961492, "longitude": -73.5800863 },
+      { "latitude": 45.4961614, "longitude": -73.5800729 },
+      { "latitude": 45.4961343, "longitude": -73.5799991 },
+      { "latitude": 45.4962949, "longitude": -73.5798436 },
+      { "latitude": 45.4965177, "longitude": -73.5796317 }
+    ]
   },
   {
     "id": "SGW-EV",
@@ -65,12 +132,40 @@
     "code": "EV",
     "name": "Engineering, Computer Science and Visual Arts Integrated Complex",
     "address": "1515 Ste-Catherine St. W.",
-    "latitude": 45.49533,
+    "latitude": 45.4956,
     "longitude": -73.57815,
     "aliases": [
       "EV",
       "EV Building",
       "Engineering, Computer Science and Visual Arts Integrated Complex"
+    ],
+    "polygon": [
+      { "latitude": 45.4959332, "longitude": -73.578441 },
+      { "latitude": 45.4956265, "longitude": -73.578729 },
+      { "latitude": 45.4956087, "longitude": -73.5787035 },
+      { "latitude": 45.4955877, "longitude": -73.5786538 },
+      { "latitude": 45.4955735, "longitude": -73.5786662 },
+      { "latitude": 45.4955639, "longitude": -73.5786747 },
+      { "latitude": 45.4955529, "longitude": -73.5786836 },
+      { "latitude": 45.4954065, "longitude": -73.5783846 },
+      { "latitude": 45.4952448, "longitude": -73.5780359 },
+      { "latitude": 45.4952542, "longitude": -73.5780238 },
+      { "latitude": 45.4951856, "longitude": -73.5778682 },
+      { "latitude": 45.4952218, "longitude": -73.5778318 },
+      { "latitude": 45.4954371, "longitude": -73.5776149 },
+      { "latitude": 45.4955018, "longitude": -73.577742 },
+      { "latitude": 45.4955147, "longitude": -73.5777306 },
+      { "latitude": 45.4955256, "longitude": -73.5777562 },
+      { "latitude": 45.4955902, "longitude": -73.5776945 },
+      { "latitude": 45.4955496, "longitude": -73.5776118 },
+      { "latitude": 45.4955134, "longitude": -73.5775381 },
+      { "latitude": 45.4958361, "longitude": -73.5772325 },
+      { "latitude": 45.495952, "longitude": -73.5774777 },
+      { "latitude": 45.4960636, "longitude": -73.5777106 },
+      { "latitude": 45.4957525, "longitude": -73.578005 },
+      { "latitude": 45.4959029, "longitude": -73.5783135 },
+      { "latitude": 45.4958841, "longitude": -73.5783336 },
+      { "latitude": 45.4959332, "longitude": -73.578441 }
     ]
   },
   {
@@ -79,9 +174,17 @@
     "code": "FA",
     "name": "FA Annex",
     "address": "2060 Mackay St.",
-    "latitude": 45.49627,
-    "longitude": -73.57922,
-    "aliases": ["FA", "FA Annex", "FA Building"]
+    "latitude": 45.49682,
+    "longitude": -73.5795,
+    "aliases": ["FA", "FA Annex", "FA Building"],
+    "polygon": [
+      { "latitude": 45.4967406, "longitude": -73.5795156 },
+      { "latitude": 45.4968443, "longitude": -73.5794153 },
+      { "latitude": 45.4968834, "longitude": -73.5794977 },
+      { "latitude": 45.4967907, "longitude": -73.5795851 },
+      { "latitude": 45.4967793, "longitude": -73.579597 },
+      { "latitude": 45.4967406, "longitude": -73.5795156 }
+    ]
   },
   {
     "id": "SGW-FB",
@@ -89,19 +192,59 @@
     "code": "FB",
     "name": "Faubourg Building",
     "address": "1250 Guy St.",
-    "latitude": 45.49485,
-    "longitude": -73.57953,
-    "aliases": ["FB", "FB Building", "Faubourg Building"]
+    "latitude": 45.49465,
+    "longitude": -73.57763,
+    "aliases": ["FB", "FB Building", "Faubourg Building"],
+    "polygon": [
+      { "latitude": 45.4946786, "longitude": -73.5780177 },
+      { "latitude": 45.4944394, "longitude": -73.5775911 },
+      { "latitude": 45.4943818, "longitude": -73.5774884 },
+      { "latitude": 45.4946349, "longitude": -73.5771989 },
+      { "latitude": 45.4946797, "longitude": -73.577282 },
+      { "latitude": 45.4946736, "longitude": -73.5772886 },
+      { "latitude": 45.4947154, "longitude": -73.57736 },
+      { "latitude": 45.4947081, "longitude": -73.5773687 },
+      { "latitude": 45.494752, "longitude": -73.5774421 },
+      { "latitude": 45.4947451, "longitude": -73.5774502 },
+      { "latitude": 45.4947858, "longitude": -73.5775203 },
+      { "latitude": 45.4947776, "longitude": -73.577528 },
+      { "latitude": 45.4948208, "longitude": -73.577598 },
+      { "latitude": 45.4948133, "longitude": -73.5776061 },
+      { "latitude": 45.4948613, "longitude": -73.577678 },
+      { "latitude": 45.4948539, "longitude": -73.5776899 },
+      { "latitude": 45.4948923, "longitude": -73.5777612 },
+      { "latitude": 45.4948598, "longitude": -73.5778026 },
+      { "latitude": 45.4948398, "longitude": -73.5778264 },
+      { "latitude": 45.4948522, "longitude": -73.5778474 },
+      { "latitude": 45.4947542, "longitude": -73.5779622 },
+      { "latitude": 45.4947429, "longitude": -73.5779414 },
+      { "latitude": 45.4946786, "longitude": -73.5780177 }
+    ]
   },
   {
     "id": "SGW-FG",
     "campus": "SGW",
     "code": "FG",
-    "name": "Faubourg Ste-Catherine Building",
+    "name": "Le Faubourg Ste-Catherine Building",
     "address": "1600 Ste-Catherine St. W.",
-    "latitude": 45.49588,
-    "longitude": -73.57761,
-    "aliases": ["FG", "FG Building", "Faubourg Ste-Catherine Building"]
+    "latitude": 45.49415,
+    "longitude": -73.57835,
+    "aliases": ["FG", "FG Building", "Faubourg Ste-Catherine Building"],
+    "polygon": [
+      { "latitude": 45.4938097, "longitude": -73.5790389 },
+      { "latitude": 45.4936147, "longitude": -73.5787064 },
+      { "latitude": 45.4944018, "longitude": -73.5777931 },
+      { "latitude": 45.4944411, "longitude": -73.5777475 },
+      { "latitude": 45.4944091, "longitude": -73.5776912 },
+      { "latitude": 45.4944119, "longitude": -73.5776335 },
+      { "latitude": 45.4944394, "longitude": -73.5775911 },
+      { "latitude": 45.4946786, "longitude": -73.5780177 },
+      { "latitude": 45.4946624, "longitude": -73.5780425 },
+      { "latitude": 45.4945866, "longitude": -73.5781316 },
+      { "latitude": 45.4945281, "longitude": -73.5782003 },
+      { "latitude": 45.4943598, "longitude": -73.5783982 },
+      { "latitude": 45.4938097, "longitude": -73.5790389 }
+    ]
   },
   {
     "id": "SGW-GA",
@@ -109,9 +252,25 @@
     "code": "GA",
     "name": "Grey Nuns Annex",
     "address": "1211 St-Mathieu St.",
-    "latitude": 45.49456,
-    "longitude": -73.57913,
-    "aliases": ["GA", "GA Annex", "GA Building", "Grey Nuns Annex"]
+    "latitude": 45.49422,
+    "longitude": -73.57785,
+    "aliases": ["GA", "GA Annex", "GA Building", "Grey Nuns Annex"],
+    "polygon": [
+      { "latitude": 45.4936289, "longitude": -73.5787043 },
+      { "latitude": 45.4935537, "longitude": -73.5785716 },
+      { "latitude": 45.494097, "longitude": -73.5779332 },
+      { "latitude": 45.4940604, "longitude": -73.5778702 },
+      { "latitude": 45.494301, "longitude": -73.5776328 },
+      { "latitude": 45.4942851, "longitude": -73.5775993 },
+      { "latitude": 45.4946366, "longitude": -73.5771809 },
+      { "latitude": 45.4946516, "longitude": -73.5772117 },
+      { "latitude": 45.4944016, "longitude": -73.5775027 },
+      { "latitude": 45.4944561, "longitude": -73.577598 },
+      { "latitude": 45.4944157, "longitude": -73.5776449 },
+      { "latitude": 45.4944101, "longitude": -73.5776918 },
+      { "latitude": 45.4944364, "longitude": -73.5777428 },
+      { "latitude": 45.4936289, "longitude": -73.5787043 }
+    ]
   },
   {
     "id": "SGW-GM",
@@ -119,9 +278,22 @@
     "code": "GM",
     "name": "Guy-De Maisonneuve Building",
     "address": "1550 De Maisonneuve Blvd. W.",
-    "latitude": 45.49637,
-    "longitude": -73.57897,
-    "aliases": ["GM", "GM Building", "Guy-De Maisonneuve Building"]
+    "latitude": 45.49587,
+    "longitude": -73.5788,
+    "aliases": ["GM", "GM Building", "Guy-De Maisonneuve Building"],
+    "polygon": [
+      { "latitude": 45.4959562, "longitude": -73.5784181 },
+      { "latitude": 45.4961299, "longitude": -73.5787809 },
+      { "latitude": 45.4959761, "longitude": -73.5789305 },
+      { "latitude": 45.4957789, "longitude": -73.5791217 },
+      { "latitude": 45.4957625, "longitude": -73.5790831 },
+      { "latitude": 45.4957825, "longitude": -73.5790637 },
+      { "latitude": 45.4957386, "longitude": -73.5789688 },
+      { "latitude": 45.4956209, "longitude": -73.5787359 },
+      { "latitude": 45.4956265, "longitude": -73.578729 },
+      { "latitude": 45.4959332, "longitude": -73.578441 },
+      { "latitude": 45.4959562, "longitude": -73.5784181 }
+    ]
   },
   {
     "id": "SGW-GN",
@@ -129,9 +301,94 @@
     "code": "GN",
     "name": "Grey Nuns Building",
     "address": "1190 Guy St.",
-    "latitude": 45.49427,
-    "longitude": -73.57975,
-    "aliases": ["GN", "GN Building", "Grey Nuns Building"]
+    "latitude": 45.49343,
+    "longitude": -73.57676,
+    "aliases": ["GN", "GN Building", "Grey Nuns Building"],
+    "polygon": [
+      { "latitude": 45.493393, "longitude": -73.5768906 },
+      { "latitude": 45.493095, "longitude": -73.5771769 },
+      { "latitude": 45.4931946, "longitude": -73.5773808 },
+      { "latitude": 45.493078, "longitude": -73.5775149 },
+      { "latitude": 45.4929671, "longitude": -73.5772923 },
+      { "latitude": 45.4929036, "longitude": -73.5773593 },
+      { "latitude": 45.4928712, "longitude": -73.5772923 },
+      { "latitude": 45.4928256, "longitude": -73.5773358 },
+      { "latitude": 45.492796, "longitude": -73.5772735 },
+      { "latitude": 45.4928392, "longitude": -73.5772285 },
+      { "latitude": 45.4928092, "longitude": -73.5771682 },
+      { "latitude": 45.4928562, "longitude": -73.5771179 },
+      { "latitude": 45.4927622, "longitude": -73.5769328 },
+      { "latitude": 45.4926888, "longitude": -73.5770106 },
+      { "latitude": 45.4926437, "longitude": -73.5769214 },
+      { "latitude": 45.4927184, "longitude": -73.5768423 },
+      { "latitude": 45.4925633, "longitude": -73.5765231 },
+      { "latitude": 45.4927227, "longitude": -73.5763696 },
+      { "latitude": 45.4928863, "longitude": -73.5767048 },
+      { "latitude": 45.4929201, "longitude": -73.5767022 },
+      { "latitude": 45.4929445, "longitude": -73.5767545 },
+      { "latitude": 45.4929295, "longitude": -73.5768014 },
+      { "latitude": 45.4930122, "longitude": -73.576965 },
+      { "latitude": 45.4933225, "longitude": -73.57667 },
+      { "latitude": 45.4933225, "longitude": -73.5766217 },
+      { "latitude": 45.4933958, "longitude": -73.5765466 },
+      { "latitude": 45.4934315, "longitude": -73.57656 },
+      { "latitude": 45.4937774, "longitude": -73.576222 },
+      { "latitude": 45.4935612, "longitude": -73.5757768 },
+      { "latitude": 45.493714, "longitude": -73.5756265 },
+      { "latitude": 45.4939293, "longitude": -73.5760799 },
+      { "latitude": 45.4940257, "longitude": -73.5759967 },
+      { "latitude": 45.4940567, "longitude": -73.576037 },
+      { "latitude": 45.494092, "longitude": -73.5760055 },
+      { "latitude": 45.4941154, "longitude": -73.5760417 },
+      { "latitude": 45.4941267, "longitude": -73.5760799 },
+      { "latitude": 45.4940896, "longitude": -73.5761148 },
+      { "latitude": 45.4941159, "longitude": -73.5761872 },
+      { "latitude": 45.4939975, "longitude": -73.5762945 },
+      { "latitude": 45.4943697, "longitude": -73.5770643 },
+      { "latitude": 45.4940595, "longitude": -73.577362 },
+      { "latitude": 45.4940933, "longitude": -73.5774344 },
+      { "latitude": 45.4939335, "longitude": -73.5775873 },
+      { "latitude": 45.4938188, "longitude": -73.5773513 },
+      { "latitude": 45.4941441, "longitude": -73.5770213 },
+      { "latitude": 45.4938583, "longitude": -73.5764259 },
+      { "latitude": 45.4935688, "longitude": -73.5767209 },
+      { "latitude": 45.4936252, "longitude": -73.5768416 },
+      { "latitude": 45.4936553, "longitude": -73.5768148 },
+      { "latitude": 45.4936694, "longitude": -73.5768296 },
+      { "latitude": 45.4936788, "longitude": -73.5768309 },
+      { "latitude": 45.4936882, "longitude": -73.5768336 },
+      { "latitude": 45.4936948, "longitude": -73.576841 },
+      { "latitude": 45.4937004, "longitude": -73.57685 },
+      { "latitude": 45.4937037, "longitude": -73.5768606 },
+      { "latitude": 45.4937042, "longitude": -73.5768732 },
+      { "latitude": 45.4937032, "longitude": -73.5768835 },
+      { "latitude": 45.4937018, "longitude": -73.5768928 },
+      { "latitude": 45.4937154, "longitude": -73.5769429 },
+      { "latitude": 45.493699, "longitude": -73.5769593 },
+      { "latitude": 45.4937559, "longitude": -73.577079 },
+      { "latitude": 45.4937117, "longitude": -73.5771286 },
+      { "latitude": 45.493706, "longitude": -73.5771689 },
+      { "latitude": 45.4936952, "longitude": -73.577195 },
+      { "latitude": 45.4936816, "longitude": -73.5772118 },
+      { "latitude": 45.4936647, "longitude": -73.5772252 },
+      { "latitude": 45.4936421, "longitude": -73.5772332 },
+      { "latitude": 45.4936214, "longitude": -73.5772332 },
+      { "latitude": 45.4936045, "longitude": -73.5772306 },
+      { "latitude": 45.4935631, "longitude": -73.5772762 },
+      { "latitude": 45.4934823, "longitude": -73.5771179 },
+      { "latitude": 45.4934692, "longitude": -73.57713 },
+      { "latitude": 45.4934565, "longitude": -73.5771313 },
+      { "latitude": 45.4934428, "longitude": -73.5771246 },
+      { "latitude": 45.4934324, "longitude": -73.5771145 },
+      { "latitude": 45.4934263, "longitude": -73.5770998 },
+      { "latitude": 45.4934235, "longitude": -73.577085 },
+      { "latitude": 45.4934238, "longitude": -73.5770673 },
+      { "latitude": 45.4934291, "longitude": -73.5770524 },
+      { "latitude": 45.4934364, "longitude": -73.5770375 },
+      { "latitude": 45.4934278, "longitude": -73.5770214 },
+      { "latitude": 45.4934438, "longitude": -73.5769993 },
+      { "latitude": 45.493393, "longitude": -73.5768906 }
+    ]
   },
   {
     "id": "SGW-GS",
@@ -139,9 +396,21 @@
     "code": "GS",
     "name": "GS Building",
     "address": "1538 Sherbrooke St. W.",
-    "latitude": 45.49598,
-    "longitude": -73.58237,
-    "aliases": ["GS", "GS Building"]
+    "latitude": 45.49661,
+    "longitude": -73.5812,
+    "aliases": ["GS", "GS Building"],
+    "polygon": [
+      { "latitude": 45.496655, "longitude": -73.5814399 },
+      { "latitude": 45.4965911, "longitude": -73.5814198 },
+      { "latitude": 45.4964312, "longitude": -73.580941 },
+      { "latitude": 45.4964905, "longitude": -73.58089 },
+      { "latitude": 45.4964801, "longitude": -73.5808565 },
+      { "latitude": 45.4965309, "longitude": -73.5808176 },
+      { "latitude": 45.4966484, "longitude": -73.5811717 },
+      { "latitude": 45.4967161, "longitude": -73.5811167 },
+      { "latitude": 45.4967894, "longitude": -73.5813165 },
+      { "latitude": 45.496655, "longitude": -73.5814399 }
+    ]
   },
   {
     "id": "SGW-H",
@@ -151,7 +420,22 @@
     "address": "1455 De Maisonneuve Blvd W.",
     "latitude": 45.49729,
     "longitude": -73.57898,
-    "aliases": ["H", "H Building", "Henry F. Hall Building"]
+    "aliases": ["H", "H Building", "Henry F. Hall Building"],
+    "polygon": [
+      { "latitude": 45.4968261, "longitude": -73.5788241 },
+      { "latitude": 45.4970373, "longitude": -73.5786245 },
+      { "latitude": 45.4972544, "longitude": -73.5784089 },
+      { "latitude": 45.4973714, "longitude": -73.5782927 },
+      { "latitude": 45.4974227, "longitude": -73.578399 },
+      { "latitude": 45.4975092, "longitude": -73.5785783 },
+      { "latitude": 45.4977164, "longitude": -73.5790075 },
+      { "latitude": 45.497713, "longitude": -73.5790121 },
+      { "latitude": 45.4974475, "longitude": -73.579269 },
+      { "latitude": 45.4971739, "longitude": -73.5795378 },
+      { "latitude": 45.4971671, "longitude": -73.5795431 },
+      { "latitude": 45.497128, "longitude": -73.5794591 },
+      { "latitude": 45.4968261, "longitude": -73.5788241 }
+    ]
   },
   {
     "id": "SGW-K",
@@ -159,9 +443,24 @@
     "code": "K",
     "name": "K Annex",
     "address": "2150 Bishop St.",
-    "latitude": 45.49758,
-    "longitude": -73.57926,
-    "aliases": ["K", "K Annex", "K Building"]
+    "latitude": 45.4978,
+    "longitude": -73.57942,
+    "aliases": ["K", "K Annex", "K Building"],
+    "polygon": [
+      { "latitude": 45.4978508, "longitude": -73.5793152 },
+      { "latitude": 45.4978723, "longitude": -73.5793612 },
+      { "latitude": 45.497887, "longitude": -73.5793896 },
+      { "latitude": 45.4977144, "longitude": -73.5795607 },
+      { "latitude": 45.4976342, "longitude": -73.579643 },
+      { "latitude": 45.4975958, "longitude": -73.5795611 },
+      { "latitude": 45.4976804, "longitude": -73.5794786 },
+      { "latitude": 45.497706, "longitude": -73.5795321 },
+      { "latitude": 45.4977493, "longitude": -73.5794813 },
+      { "latitude": 45.4977435, "longitude": -73.5794647 },
+      { "latitude": 45.49777, "longitude": -73.5794334 },
+      { "latitude": 45.4977565, "longitude": -73.579405 },
+      { "latitude": 45.4978508, "longitude": -73.5793152 }
+    ]
   },
   {
     "id": "SGW-LB",
@@ -169,9 +468,40 @@
     "code": "LB",
     "name": "J.W. McConnell Building",
     "address": "1400 De Maisonneuve Blvd W.",
-    "latitude": 45.4978,
-    "longitude": -73.57818,
-    "aliases": ["LB", "LB Building", "J.W. McConnell Building"]
+    "latitude": 45.4968,
+    "longitude": -73.5779,
+    "aliases": ["LB", "LB Building", "J.W. McConnell Building"],
+    "polygon": [
+      { "latitude": 45.4966595, "longitude": -73.5785573 },
+      { "latitude": 45.4964933, "longitude": -73.5782102 },
+      { "latitude": 45.4962682, "longitude": -73.57774 },
+      { "latitude": 45.4962438, "longitude": -73.5776884 },
+      { "latitude": 45.4964601, "longitude": -73.5774775 },
+      { "latitude": 45.4964854, "longitude": -73.5774533 },
+      { "latitude": 45.4965695, "longitude": -73.5776244 },
+      { "latitude": 45.4965785, "longitude": -73.5776438 },
+      { "latitude": 45.4966005, "longitude": -73.5776912 },
+      { "latitude": 45.4966303, "longitude": -73.5776683 },
+      { "latitude": 45.4966522, "longitude": -73.5776483 },
+      { "latitude": 45.496632, "longitude": -73.5776045 },
+      { "latitude": 45.4966195, "longitude": -73.5775774 },
+      { "latitude": 45.4966092, "longitude": -73.5775555 },
+      { "latitude": 45.4968912, "longitude": -73.5772806 },
+      { "latitude": 45.4969031, "longitude": -73.5773036 },
+      { "latitude": 45.4969457, "longitude": -73.577393 },
+      { "latitude": 45.4970355, "longitude": -73.5775784 },
+      { "latitude": 45.4971222, "longitude": -73.5777573 },
+      { "latitude": 45.49717, "longitude": -73.577856 },
+      { "latitude": 45.4972443, "longitude": -73.5780094 },
+      { "latitude": 45.4972616, "longitude": -73.578045 },
+      { "latitude": 45.4969852, "longitude": -73.578317 },
+      { "latitude": 45.4969634, "longitude": -73.5782783 },
+      { "latitude": 45.4969052, "longitude": -73.5783211 },
+      { "latitude": 45.4969277, "longitude": -73.5783716 },
+      { "latitude": 45.496716, "longitude": -73.5785731 },
+      { "latitude": 45.4966932, "longitude": -73.578525 },
+      { "latitude": 45.4966595, "longitude": -73.5785573 }
+    ]
   },
   {
     "id": "SGW-LD",
@@ -179,9 +509,20 @@
     "code": "LD",
     "name": "LD Building",
     "address": "1424 Bishop St.",
-    "latitude": 45.4985,
-    "longitude": -73.57912,
-    "aliases": ["LD", "LD Building"]
+    "latitude": 45.49673,
+    "longitude": -73.57726,
+    "aliases": ["LD", "LD Building"],
+    "polygon": [
+      { "latitude": 45.4968552, "longitude": -73.5772077 },
+      { "latitude": 45.4966654, "longitude": -73.577382 },
+      { "latitude": 45.4966616, "longitude": -73.5773673 },
+      { "latitude": 45.4965808, "longitude": -73.5774437 },
+      { "latitude": 45.4965545, "longitude": -73.577382 },
+      { "latitude": 45.4966381, "longitude": -73.5773016 },
+      { "latitude": 45.4966344, "longitude": -73.5772922 },
+      { "latitude": 45.496813, "longitude": -73.5771179 },
+      { "latitude": 45.4968552, "longitude": -73.5772077 }
+    ]
   },
   {
     "id": "SGW-LS",
@@ -189,9 +530,18 @@
     "code": "LS",
     "name": "Learning Square",
     "address": "1535 De Maisonneuve Blvd W.",
-    "latitude": 45.49689,
-    "longitude": -73.5805,
-    "aliases": ["LS", "LS Building", "Learning Square"]
+    "latitude": 45.49635,
+    "longitude": -73.5795,
+    "aliases": ["LS", "LS Building", "Learning Square"],
+    "polygon": [
+      { "latitude": 45.4961716, "longitude": -73.5794628 },
+      { "latitude": 45.4963919, "longitude": -73.5792514 },
+      { "latitude": 45.496534, "longitude": -73.5795528 },
+      { "latitude": 45.4964097, "longitude": -73.579672 },
+      { "latitude": 45.4963629, "longitude": -73.5795726 },
+      { "latitude": 45.4962668, "longitude": -73.5796648 },
+      { "latitude": 45.4961716, "longitude": -73.5794628 }
+    ]
   },
   {
     "id": "SGW-M",
@@ -199,9 +549,21 @@
     "code": "M",
     "name": "M Annex",
     "address": "2135 Mackay St.",
-    "latitude": 45.49716,
-    "longitude": -73.57977,
-    "aliases": ["M", "M Annex", "M Building"]
+    "latitude": 45.49735,
+    "longitude": -73.57975,
+    "aliases": ["M", "M Annex", "M Building"],
+    "polygon": [
+      { "latitude": 45.4974204, "longitude": -73.5797377 },
+      { "latitude": 45.4973206, "longitude": -73.5798361 },
+      { "latitude": 45.4973116, "longitude": -73.5798209 },
+      { "latitude": 45.4973058, "longitude": -73.5798082 },
+      { "latitude": 45.4972922, "longitude": -73.579803 },
+      { "latitude": 45.4972817, "longitude": -73.579781 },
+      { "latitude": 45.4972844, "longitude": -73.5797586 },
+      { "latitude": 45.4973882, "longitude": -73.5796579 },
+      { "latitude": 45.4974254, "longitude": -73.5797325 },
+      { "latitude": 45.4974204, "longitude": -73.5797377 }
+    ]
   },
   {
     "id": "SGW-MB",
@@ -209,9 +571,31 @@
     "code": "MB",
     "name": "John Molson Building",
     "address": "1450 Guy St.",
-    "latitude": 45.49676,
-    "longitude": -73.57879,
-    "aliases": ["MB", "MB Building", "John Molson Building"]
+    "latitude": 45.49526,
+    "longitude": -73.57905,
+    "aliases": ["MB", "MB Building", "John Molson Building"],
+    "polygon": [
+      { "latitude": 45.4949482, "longitude": -73.5787947 },
+      { "latitude": 45.4950064, "longitude": -73.5787235 },
+      { "latitude": 45.4951687, "longitude": -73.5785025 },
+      { "latitude": 45.4952044, "longitude": -73.5784643 },
+      { "latitude": 45.4952249, "longitude": -73.5785117 },
+      { "latitude": 45.4953768, "longitude": -73.5788545 },
+      { "latitude": 45.4954184, "longitude": -73.5789152 },
+      { "latitude": 45.495487, "longitude": -73.5790796 },
+      { "latitude": 45.4954792, "longitude": -73.5790862 },
+      { "latitude": 45.4955248, "longitude": -73.5791931 },
+      { "latitude": 45.4955404, "longitude": -73.5792286 },
+      { "latitude": 45.4954131, "longitude": -73.579399 },
+      { "latitude": 45.4954061, "longitude": -73.5794075 },
+      { "latitude": 45.495405, "longitude": -73.5794087 },
+      { "latitude": 45.4952737, "longitude": -73.5795675 },
+      { "latitude": 45.4952576, "longitude": -73.5795406 },
+      { "latitude": 45.4951565, "longitude": -73.5793716 },
+      { "latitude": 45.4951179, "longitude": -73.5793059 },
+      { "latitude": 45.495187, "longitude": -73.5792261 },
+      { "latitude": 45.4949482, "longitude": -73.5787947 }
+    ]
   },
   {
     "id": "SGW-MI",
@@ -219,9 +603,22 @@
     "code": "MI",
     "name": "MI Annex",
     "address": "2130 Bishop St.",
-    "latitude": 45.49707,
-    "longitude": -73.57903,
-    "aliases": ["MI", "MI Annex", "MI Building"]
+    "latitude": 45.49773,
+    "longitude": -73.57927,
+    "aliases": ["MI", "MI Annex", "MI Building"],
+    "polygon": [
+      { "latitude": 45.4977756, "longitude": -73.5791541 },
+      { "latitude": 45.4977976, "longitude": -73.5792006 },
+      { "latitude": 45.497816, "longitude": -73.5792401 },
+      { "latitude": 45.4977169, "longitude": -73.5793354 },
+      { "latitude": 45.4976434, "longitude": -73.5794029 },
+      { "latitude": 45.4976312, "longitude": -73.5793776 },
+      { "latitude": 45.4976213, "longitude": -73.5793546 },
+      { "latitude": 45.4976914, "longitude": -73.5792819 },
+      { "latitude": 45.4976783, "longitude": -73.5792544 },
+      { "latitude": 45.4977448, "longitude": -73.5791871 },
+      { "latitude": 45.4977756, "longitude": -73.5791541 }
+    ]
   },
   {
     "id": "SGW-MU",
@@ -229,9 +626,18 @@
     "code": "MU",
     "name": "MU Annex",
     "address": "2170 Bishop St.",
-    "latitude": 45.49809,
-    "longitude": -73.58003,
-    "aliases": ["MU", "MU Annex", "MU Building"]
+    "latitude": 45.49789,
+    "longitude": -73.57955,
+    "aliases": ["MU", "MU Annex", "MU Building"],
+    "polygon": [
+      { "latitude": 45.4979241, "longitude": -73.5794655 },
+      { "latitude": 45.4979399, "longitude": -73.5794938 },
+      { "latitude": 45.4979605, "longitude": -73.5795368 },
+      { "latitude": 45.4977466, "longitude": -73.579754 },
+      { "latitude": 45.4977075, "longitude": -73.5796772 },
+      { "latitude": 45.4977507, "longitude": -73.5796322 },
+      { "latitude": 45.4979241, "longitude": -73.5794655 }
+    ]
   },
   {
     "id": "SGW-P",
@@ -239,9 +645,17 @@
     "code": "P",
     "name": "P Annex",
     "address": "2020 Mackay St.",
-    "latitude": 45.49607,
-    "longitude": -73.57902,
-    "aliases": ["P", "P Annex", "P Building"]
+    "latitude": 45.49666,
+    "longitude": -73.57918,
+    "aliases": ["P", "P Annex", "P Building"],
+    "polygon": [
+      { "latitude": 45.496684, "longitude": -73.5790979 },
+      { "latitude": 45.4967207, "longitude": -73.5791744 },
+      { "latitude": 45.4967172, "longitude": -73.5791776 },
+      { "latitude": 45.496621, "longitude": -73.5792669 },
+      { "latitude": 45.4965857, "longitude": -73.5791899 },
+      { "latitude": 45.496684, "longitude": -73.5790979 }
+    ]
   },
   {
     "id": "SGW-PR",
@@ -249,9 +663,29 @@
     "code": "PR",
     "name": "PR Annex",
     "address": "2100 Mackay St.",
-    "latitude": 45.49678,
-    "longitude": -73.57965,
-    "aliases": ["PR", "PR Annex", "PR Building"]
+    "latitude": 45.49697,
+    "longitude": -73.57983,
+    "aliases": ["PR", "PR Annex", "PR Building"],
+    "polygon": [
+      { "latitude": 45.4969999, "longitude": -73.5797534 },
+      { "latitude": 45.4970082, "longitude": -73.5797457 },
+      { "latitude": 45.4970309, "longitude": -73.579795 },
+      { "latitude": 45.4970326, "longitude": -73.5798276 },
+      { "latitude": 45.4969316, "longitude": -73.5799272 },
+      { "latitude": 45.4969346, "longitude": -73.579949 },
+      { "latitude": 45.4969279, "longitude": -73.5799345 },
+      { "latitude": 45.4968886, "longitude": -73.5799699 },
+      { "latitude": 45.4968946, "longitude": -73.5799898 },
+      { "latitude": 45.4968248, "longitude": -73.5800496 },
+      { "latitude": 45.4967823, "longitude": -73.5799532 },
+      { "latitude": 45.4968411, "longitude": -73.5798979 },
+      { "latitude": 45.4968489, "longitude": -73.5798908 },
+      { "latitude": 45.4968741, "longitude": -73.5799469 },
+      { "latitude": 45.4969163, "longitude": -73.5799082 },
+      { "latitude": 45.4968917, "longitude": -73.5798536 },
+      { "latitude": 45.4969027, "longitude": -73.5798436 },
+      { "latitude": 45.4969999, "longitude": -73.5797534 }
+    ]
   },
   {
     "id": "SGW-Q",
@@ -259,9 +693,17 @@
     "code": "Q",
     "name": "Q Annex",
     "address": "2010 Mackay St.",
-    "latitude": 45.496,
-    "longitude": -73.57893,
-    "aliases": ["Q", "Q Annex", "Q Building"]
+    "latitude": 45.4966,
+    "longitude": -73.57913,
+    "aliases": ["Q", "Q Annex", "Q Building"],
+    "polygon": [
+      { "latitude": 45.496652, "longitude": -73.579029 },
+      { "latitude": 45.496684, "longitude": -73.5790979 },
+      { "latitude": 45.4965857, "longitude": -73.5791899 },
+      { "latitude": 45.4965778, "longitude": -73.5791972 },
+      { "latitude": 45.4965484, "longitude": -73.579129 },
+      { "latitude": 45.496652, "longitude": -73.579029 }
+    ]
   },
   {
     "id": "SGW-R",
@@ -269,9 +711,16 @@
     "code": "R",
     "name": "R Annex",
     "address": "2050 Mackay St.",
-    "latitude": 45.4963,
-    "longitude": -73.57922,
-    "aliases": ["R", "R Annex", "R Building"]
+    "latitude": 45.49677,
+    "longitude": -73.57942,
+    "aliases": ["R", "R Annex", "R Building"],
+    "polygon": [
+      { "latitude": 45.4967012, "longitude": -73.5794243 },
+      { "latitude": 45.4968027, "longitude": -73.5793309 },
+      { "latitude": 45.4968443, "longitude": -73.5794153 },
+      { "latitude": 45.4967406, "longitude": -73.5795156 },
+      { "latitude": 45.4967012, "longitude": -73.5794243 }
+    ]
   },
   {
     "id": "SGW-RR",
@@ -279,9 +728,19 @@
     "code": "RR",
     "name": "RR Annex",
     "address": "2040 Mackay St.",
-    "latitude": 45.49624,
-    "longitude": -73.57914,
-    "aliases": ["RR", "RR Annex", "RR Building"]
+    "latitude": 45.49672,
+    "longitude": -73.57934,
+    "aliases": ["RR", "RR Annex", "RR Building"],
+    "polygon": [
+      { "latitude": 45.4967535, "longitude": -73.5792532 },
+      { "latitude": 45.4967635, "longitude": -73.579244 },
+      { "latitude": 45.4968027, "longitude": -73.5793309 },
+      { "latitude": 45.4967012, "longitude": -73.5794243 },
+      { "latitude": 45.4966525, "longitude": -73.5794691 },
+      { "latitude": 45.496613, "longitude": -73.5793816 },
+      { "latitude": 45.496657, "longitude": -73.5793412 },
+      { "latitude": 45.4967535, "longitude": -73.5792532 }
+    ]
   },
   {
     "id": "SGW-S",
@@ -289,19 +748,45 @@
     "code": "S",
     "name": "S Annex",
     "address": "2145 Mackay St.",
-    "latitude": 45.49729,
-    "longitude": -73.57994,
-    "aliases": ["S", "S Annex", "S Building"]
+    "latitude": 45.49739,
+    "longitude": -73.57983,
+    "aliases": ["S", "S Annex", "S Building"],
+    "polygon": [
+      { "latitude": 45.4974912, "longitude": -73.5798023 },
+      { "latitude": 45.4973632, "longitude": -73.5799218 },
+      { "latitude": 45.4973547, "longitude": -73.5799045 },
+      { "latitude": 45.4973455, "longitude": -73.5798855 },
+      { "latitude": 45.4973335, "longitude": -73.5798829 },
+      { "latitude": 45.497321, "longitude": -73.5798567 },
+      { "latitude": 45.4973206, "longitude": -73.5798361 },
+      { "latitude": 45.4974204, "longitude": -73.5797377 },
+      { "latitude": 45.4974321, "longitude": -73.5797603 },
+      { "latitude": 45.4974585, "longitude": -73.5797346 },
+      { "latitude": 45.4974912, "longitude": -73.5798023 }
+    ]
   },
   {
     "id": "SGW-SB",
     "campus": "SGW",
     "code": "SB",
     "name": "Samuel Bronfman Building",
-    "address": "1590 Dr. Penfield",
-    "latitude": 45.49897,
-    "longitude": -73.58604,
-    "aliases": ["SB", "SB Building", "Samuel Bronfman Building"]
+    "address": "1590 Dr. Penfield Ave",
+    "latitude": 45.49659,
+    "longitude": -73.58609,
+    "aliases": ["SB", "SB Building", "Samuel Bronfman Building"],
+    "polygon": [
+      { "latitude": 45.4965801, "longitude": -73.5858404 },
+      { "latitude": 45.496699, "longitude": -73.5861354 },
+      { "latitude": 45.496519, "longitude": -73.586287 },
+      { "latitude": 45.4964471, "longitude": -73.5862668 },
+      { "latitude": 45.4964861, "longitude": -73.5858665 },
+      { "latitude": 45.4964988, "longitude": -73.5858625 },
+      { "latitude": 45.4965293, "longitude": -73.5858685 },
+      { "latitude": 45.4965458, "longitude": -73.5859074 },
+      { "latitude": 45.4965617, "longitude": -73.5858927 },
+      { "latitude": 45.4965491, "longitude": -73.5858645 },
+      { "latitude": 45.4965801, "longitude": -73.5858404 }
+    ]
   },
   {
     "id": "SGW-T",
@@ -309,9 +794,16 @@
     "code": "T",
     "name": "T Annex",
     "address": "2030 Mackay St.",
-    "latitude": 45.49616,
-    "longitude": -73.57909,
-    "aliases": ["T", "T Annex", "T Building"]
+    "latitude": 45.496688,
+    "longitude": -73.57926,
+    "aliases": ["T", "T Annex", "T Building"],
+    "polygon": [
+      { "latitude": 45.4967172, "longitude": -73.5791776 },
+      { "latitude": 45.4967535, "longitude": -73.5792532 },
+      { "latitude": 45.496657, "longitude": -73.5793412 },
+      { "latitude": 45.496621, "longitude": -73.5792669 },
+      { "latitude": 45.4967172, "longitude": -73.5791776 }
+    ]
   },
   {
     "id": "SGW-TD",
@@ -319,9 +811,23 @@
     "code": "TD",
     "name": "Toronto-Dominion Building",
     "address": "1410 Guy St.",
-    "latitude": 45.4969,
-    "longitude": -73.57979,
-    "aliases": ["TD", "TD Building", "Toronto-Dominion Building"]
+    "latitude": 45.49502,
+    "longitude": -73.57819,
+    "aliases": ["TD", "TD Building", "Toronto-Dominion Building"],
+    "polygon": [
+      { "latitude": 45.4951729, "longitude": -73.5783952 },
+      { "latitude": 45.4951046, "longitude": -73.5784763 },
+      { "latitude": 45.4950277, "longitude": -73.5783336 },
+      { "latitude": 45.4950446, "longitude": -73.5783148 },
+      { "latitude": 45.4950258, "longitude": -73.5782746 },
+      { "latitude": 45.495006, "longitude": -73.5783014 },
+      { "latitude": 45.4949224, "longitude": -73.5781512 },
+      { "latitude": 45.494986, "longitude": -73.5780834 },
+      { "latitude": 45.4950185, "longitude": -73.5780446 },
+      { "latitude": 45.4951387, "longitude": -73.5783164 },
+      { "latitude": 45.495163, "longitude": -73.5783712 },
+      { "latitude": 45.4951729, "longitude": -73.5783952 }
+    ]
   },
   {
     "id": "SGW-V",
@@ -329,9 +835,19 @@
     "code": "V",
     "name": "V Annex",
     "address": "2110 Mackay St.",
-    "latitude": 45.49686,
-    "longitude": -73.57975,
-    "aliases": ["V", "V Annex", "V Building"]
+    "latitude": 45.497009,
+    "longitude": -73.57993,
+    "aliases": ["V", "V Annex", "V Building"],
+    "polygon": [
+      { "latitude": 45.4970326, "longitude": -73.5798276 },
+      { "latitude": 45.4970504, "longitude": -73.579812 },
+      { "latitude": 45.4970779, "longitude": -73.5798721 },
+      { "latitude": 45.4970896, "longitude": -73.5798984 },
+      { "latitude": 45.4970717, "longitude": -73.5799152 },
+      { "latitude": 45.4969695, "longitude": -73.5800161 },
+      { "latitude": 45.4969316, "longitude": -73.5799272 },
+      { "latitude": 45.4970326, "longitude": -73.5798276 }
+    ]
   },
   {
     "id": "SGW-VA",
@@ -339,9 +855,22 @@
     "code": "VA",
     "name": "Visual Arts Building",
     "address": "1395 René-Lévesque Blvd W.",
-    "latitude": 45.49669,
-    "longitude": -73.5809,
-    "aliases": ["VA", "VA Building", "Visual Arts Building"]
+    "latitude": 45.49565,
+    "longitude": -73.5739,
+    "aliases": ["VA", "VA Building", "Visual Arts Building"],
+    "polygon": [
+      { "latitude": 45.4961732, "longitude": -73.5737903 },
+      { "latitude": 45.4956505, "longitude": -73.5742947 },
+      { "latitude": 45.4953889, "longitude": -73.5737454 },
+      { "latitude": 45.4956493, "longitude": -73.5734921 },
+      { "latitude": 45.4956638, "longitude": -73.5735228 },
+      { "latitude": 45.4957798, "longitude": -73.5738088 },
+      { "latitude": 45.4957967, "longitude": -73.5737954 },
+      { "latitude": 45.4957995, "longitude": -73.5738039 },
+      { "latitude": 45.4958122, "longitude": -73.5737944 },
+      { "latitude": 45.4960569, "longitude": -73.573549 },
+      { "latitude": 45.4961732, "longitude": -73.5737903 }
+    ]
   },
   {
     "id": "SGW-X",
@@ -349,9 +878,16 @@
     "code": "X",
     "name": "X Annex",
     "address": "2080 Mackay St.",
-    "latitude": 45.49646,
-    "longitude": -73.57949,
-    "aliases": ["X", "X Annex", "X Building"]
+    "latitude": 45.49689,
+    "longitude": -73.57968,
+    "aliases": ["X", "X Annex", "X Building"],
+    "polygon": [
+      { "latitude": 45.4969271, "longitude": -73.5795884 },
+      { "latitude": 45.4969613, "longitude": -73.5796672 },
+      { "latitude": 45.4968645, "longitude": -73.5797555 },
+      { "latitude": 45.4968297, "longitude": -73.5796809 },
+      { "latitude": 45.4969271, "longitude": -73.5795884 }
+    ]
   },
   {
     "id": "SGW-Z",
@@ -359,8 +895,22 @@
     "code": "Z",
     "name": "Z Annex",
     "address": "2090 Mackay St.",
-    "latitude": 45.49656,
-    "longitude": -73.57959,
-    "aliases": ["Z", "Z Annex", "Z Building"]
+    "latitude": 45.49693,
+    "longitude": -73.57975,
+    "aliases": ["Z", "Z Annex", "Z Building"],
+    "polygon": [
+      { "latitude": 45.4968645, "longitude": -73.5797555 },
+      { "latitude": 45.4969613, "longitude": -73.5796672 },
+      { "latitude": 45.4969999, "longitude": -73.5797534 },
+      { "latitude": 45.4969027, "longitude": -73.5798436 },
+      { "latitude": 45.4968899, "longitude": -73.5798153 },
+      { "latitude": 45.4968711, "longitude": -73.5798326 },
+      { "latitude": 45.4968827, "longitude": -73.5798585 },
+      { "latitude": 45.4968489, "longitude": -73.5798908 },
+      { "latitude": 45.4968411, "longitude": -73.5798979 },
+      { "latitude": 45.4968151, "longitude": -73.5798399 },
+      { "latitude": 45.496877, "longitude": -73.5797833 },
+      { "latitude": 45.4968645, "longitude": -73.5797555 }
+    ]
   }
 ]


### PR DESCRIPTION
I added coordinates for SGW building shapes in SGW_data.json, including the corresponding building code labels and red color.
They are now available on the map, as well as for Loyola campus buildings.
All building shapes remained tappable, for the pop-up implementation later.

All tasks for US-3 are officially completed (T-3.1, T-3.2, T3.3, T-3.4 and T-3.5)

Big shoutout to @Gibraltar-47 !! You helped me in the modification of SGW_data.json file as well as for providing me resources to work on this task.

Notice: 
In case we need to modify any attribute in Building class as our main model, go to /main/components/types.ts and add the needed attributes. Then, you can put the corresponding data value in /main/components/Buildings/data/#####_data.json file (SGW or Loyola). That could be useful for your US-6 @Samaya-Anwar 

<img width="660" height="1434" alt="IMG_3161" src="https://github.com/user-attachments/assets/d544fe9a-7b3a-42cf-9ac6-a51274b1254b" />

<img width="660" height="1434" alt="IMG_3162 2" src="https://github.com/user-attachments/assets/85f1c38c-059a-4c50-b339-2c28b30f6af7" />

<img width="660" height="1434" alt="IMG_3163" src="https://github.com/user-attachments/assets/4ccccbb5-9fca-4ed6-b4e5-0b5be214c9d2" />
 
<img width="660" height="1434" alt="IMG_3165" src="https://github.com/user-attachments/assets/19ff55e2-15ff-4bfd-8a4e-be84fae4b309" />